### PR TITLE
Create lximage-qt_it.desktop

### DIFF
--- a/src/translations/lximage-qt_it.desktop
+++ b/src/translations/lximage-qt_it.desktop
@@ -1,0 +1,3 @@
+#Translations
+Name[it]=Visualizzatore immagini
+Comment[it]=Il visualizzatore immagini di LXQt


### PR DESCRIPTION
Menu displays Name= not GenericName=, 
It it get's displayed under "Accessories"   not under "Graphics", no idea why.