### PR TITLE
Don't save file in private mode

### DIFF
--- a/src/saveimagejob.cpp
+++ b/src/saveimagejob.cpp
@@ -40,7 +40,7 @@ SaveImageJob::~SaveImageJob() {
 // This is called from the worker thread, not main thread
 bool SaveImageJob::run() {
   GFile* gfile = fm_path_to_gfile(path_);
-  GFileOutputStream* fileStream = g_file_replace(gfile, NULL, false, G_FILE_CREATE_PRIVATE, cancellable_, &error_);
+  GFileOutputStream* fileStream = g_file_replace(gfile, NULL, false, G_FILE_CREATE_NONE, cancellable_, &error_);
   g_object_unref(gfile);
 
   if(fileStream) { // if the file stream is successfually opened


### PR DESCRIPTION
With this flag, the default file permissions seems to be used when
creating new files, and permissions to existing files are conserved when
saving (except when changing the permission explicitely of course).

See: http://www.freedesktop.org/software/gstreamer-sdk/data/docs/latest/gio/GFile.html#GFileCreateFlags

Fixes #25.