### PR TITLE
Set the color table properly for scaled images

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -226,6 +226,12 @@ void ImageView::generateCache() {
   const uchar* bits = image_.constBits();
   unsigned int offset = subRect.x() * image_.depth() / 8 + subRect.y() * image_.bytesPerLine();
   QImage subImage = QImage(bits + offset, subRect.width(), subRect.height(), image_.bytesPerLine(), image_.format());
+
+  // If the original image has a color table, also use it for the subImage
+  QVector<QRgb> colorTable = image_.colorTable();
+  if (!colorTable.empty())
+    subImage.setColorTable(colorTable);
+
   // QImage scaled = subImage.scaled(subRect.width() * scaleFactor_, subRect.height() * scaleFactor_, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   QImage scaled = subImage.scaled(cachedRect_.width(), cachedRect_.height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
 


### PR DESCRIPTION
To generate the cached pixmap for scaled images, only the raw data was used, without considering the color table. Without the color table, the produced pixmap is not correct, in particular this caused the problem seen in issue #6, when the screen is black, it's because the cached pixmap with the wrong color table is displayed, this is why you can catch a glimpse of the original image before the pixmap is loaded, and also why the image is displayed properly when no scaling is applied.

This pull request ensures that the color table, if present, is used to generate the pixmap, thus fixing issue #6.