### PR TITLE
Fix missing Russian translation in desktop file

### DIFF
--- a/src/translations/lximage-qt_ru.desktop
+++ b/src/translations/lximage-qt_ru.desktop
@@ -1,4 +1,4 @@
 #Translations
-Name=LXImage
-GenericName=Просмотрщик изображений
-Comment=Просмотрщик изображений LXQt
+Name[ru]=LXImage
+GenericName[ru]=Просмотрщик изображений
+Comment[ru]=Просмотрщик изображений LXQt


### PR DESCRIPTION
The Russian translation for the desktop entry was not included into the final desktop file because its keys did not end with the locale postfix.

Thanks!