### PR TITLE
Implement an EOG-like behavior on starting

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -154,7 +154,9 @@ void Application::newWindow(QStringList files) {
       if(settings_.windowMaximized())
         window->setWindowState(window->windowState() | Qt::WindowMaximized);
 
-      window->show();
+      /* when there's an image, we show the window AFTER resizing
+         and centering it appropriately at MainWindow::updateUI() */
+      //window->show();
     }
   }
 }


### PR DESCRIPTION
By clicking on an image for the first time, the user wants to see it clearly with lximage-qt. So, the following behavior is implemented here:

(1) A minimum size of 400x400 is assumed;
(2) The window is scaled to fit the image;
(3) For too big images, the window is scaled down;
(4) The window is centered on the screen.
(5) The loaded image is selected and centered in the thumbnail view.

This also addresses #43.