### PR TITLE
Copy File Name

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -104,6 +104,8 @@ MainWindow::MainWindow():
   contextMenu_->addAction(ui.actionFlipHorizontal);
   contextMenu_->addAction(ui.actionFlipVertical);
   contextMenu_->addAction(ui.actionFlipVertical);
+  contextMenu_->addSeparator();
+  contextMenu_->addAction(ui.actionCopyFileName);
 
   // create shortcuts
   QShortcut* shortcut = new QShortcut(Qt::Key_Left, this);
@@ -647,6 +649,12 @@ void MainWindow::on_actionCopy_triggered() {
     copiedImage = image_.scaled();
   */
   clipboard->setImage(copiedImage);
+}
+
+void MainWindow::on_actionCopyFileName_triggered() {
+  QClipboard *clipboard = QApplication::clipboard();
+  printf("Test!\n");
+  //clipboard->setImage(copiedImage);
 }
 
 void MainWindow::on_actionPaste_triggered() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -651,10 +651,13 @@ void MainWindow::on_actionCopy_triggered() {
   clipboard->setImage(copiedImage);
 }
 
+// Function for grabbing the full path of the current fil loaded.
 void MainWindow::on_actionCopyFileName_triggered() {
   QClipboard *clipboard = QApplication::clipboard();
-  printf("Test!\n");
-  //clipboard->setImage(copiedImage);
+  if(currentFile_) { //Ensure file is a valid path.
+    clipboard->setText(fm_path_to_str(currentFile_)); //Set the clipboard to be the current path of the current image.
+  }
+
 }
 
 void MainWindow::on_actionPaste_triggered() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -86,6 +86,8 @@ protected:
 private Q_SLOTS:
   void on_actionAbout_triggered();
 
+  void on_actionCopyFileName_triggered();
+
   void on_actionOpenFile_triggered();
   void on_actionNewWindow_triggered();
   void on_actionSave_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -147,6 +147,7 @@
    <addaction name="actionOriginalSize"/>
    <addaction name="separator"/>
    <addaction name="actionSlideShow"/>
+   <addaction name="actionCopyFileName"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionAbout">
@@ -450,6 +451,11 @@
    <property name="text">
     <string>File Properties</string>
    </property>
+  </action>
+  <action name="actionCopyFileName">
+    <property name="text">
+      <string>Copy File Name</string>
+      </property>
   </action>
  </widget>
  <customwidgets>


### PR DESCRIPTION
Hello, I would like to contribute a feature I made for my own personal usage. I added a button to the toolbar and a right-click menu item that copies the file path of the currently opened image to the clipboard. I know it seems simple, but this is a huge help for me, especially when going through thousands of images for sorting purposes. I don't know much about libfm or Qt, but I made something that works, and followed the contribution guide as best I could within my memory's limits. I use this myself, so I suppose others might find it useful too.