### PR TITLE
Hide cursor smartly in fullscreen mode

### DIFF
--- a/src/imageview.h
+++ b/src/imageview.h
@@ -67,9 +67,16 @@ public:
     autoZoomFit_ = value;
   }
 
+  // if set to true, hides the cursor after 3s of inactivity
+  void hideCursor(bool enable);
+
 protected:
   virtual void wheelEvent(QWheelEvent* event);
   virtual void mouseDoubleClickEvent(QMouseEvent* event);
+  virtual void mousePressEvent(QMouseEvent* event);
+  virtual void mouseReleaseEvent(QMouseEvent* event);
+  virtual void mouseMoveEvent(QMouseEvent* event);
+  virtual void focusInEvent(QFocusEvent* event);
   virtual void resizeEvent(QResizeEvent* event);
   virtual void paintEvent(QPaintEvent* event);
 
@@ -80,6 +87,7 @@ private:
 
 private Q_SLOTS:
   void generateCache();
+  void blankCursor();
 
 private:
   QGraphicsScene* scene_; // the topmost container of all graphic items
@@ -90,6 +98,7 @@ private:
   QRect cachedRect_; // rectangle containing the cached region (in viewport coordinate)
   QRect cachedSceneRect_; // rectangle containing the cached region (in scene/original image coordinate)
   QTimer* cacheTimer_;
+  QTimer *cursorTimer_; // for hiding cursor in fullscreen mode
   double scaleFactor_;
   bool autoZoomFit_;
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -876,6 +876,7 @@ void MainWindow::changeEvent(QEvent* event) {
           addAction(action);
       }
       addActions(ui.menubar->actions());
+      ui.view->hideCursor(true);
     }
     else { // restore to normal window mode
       ui.view->setFrameStyle(QFrame::StyledPanel|QFrame::Sunken);
@@ -890,6 +891,7 @@ void MainWindow::changeEvent(QEvent* event) {
       ui.statusBar->show();
       if(thumbnailsDock_)
         thumbnailsDock_->show();
+      ui.view->hideCursor(false);
     }
   }
   QWidget::changeEvent(event);


### PR DESCRIPTION
This commit hides the cursor in the fullscreen mode after 3 seconds of inactivity and shows it again when needed.