### PR TITLE
Treat SVG files separately as SVG images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(Qt5DBus REQUIRED)
 find_package(Qt5PrintSupport REQUIRED QUIET)
 find_package(Qt5X11Extras REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
+find_package(Qt5Svg REQUIRED QUIET)
 find_package(fm-qt REQUIRED QUIET)
 find_package(lxqt REQUIRED) #just a build dependency for .desktop files translation
 message(STATUS "Building with Qt ${Qt5Core_VERSION_STRING}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ add_definitions(
     -DLXIMAGE_VERSION="${LXIMAGE_VERSION}"
 )
 
-set(QT_LIBRARIES Qt5::Widgets Qt5::Core Qt5::DBus Qt5::PrintSupport Qt5::X11Extras)
+set(QT_LIBRARIES Qt5::Widgets Qt5::Core Qt5::DBus Qt5::PrintSupport Qt5::X11Extras Qt5::Svg)
 
 target_link_libraries(lximage-qt
     fm-qt

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -179,6 +179,6 @@ void Application::editPreferences() {
 }
 
 void Application::onAboutToQuit() {
-  qDebug("aboutToQuit");
+  //qDebug("aboutToQuit");
   settings_.save();
 }

--- a/src/application.h
+++ b/src/application.h
@@ -41,11 +41,11 @@ public:
 
   void addWindow() { // call this when you create a new toplevel window
     ++windowCount_;
-    qDebug("add window");
+    //qDebug("add window");
   }
 
   void removeWindow() { // call this when you destroy a toplevel window
-    qDebug("remove window");
+    //qDebug("remove window");
     --windowCount_;
     if(0 == windowCount_)
       quit();

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -42,6 +42,7 @@ public:
 
   void setImage(QImage image, bool show = true);
   void setGifAnimation(QString fileName);
+  void setSVG(QString fileName);
 
   QImage image() {
     return image_;
@@ -101,6 +102,7 @@ private:
   QTimer *cursorTimer_; // for hiding cursor in fullscreen mode
   double scaleFactor_;
   bool autoZoomFit_;
+  bool isSVG; // is the image an SVG file?
 };
 
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -126,7 +126,7 @@ private:
   void updateUI();
   void setModified(bool modified);
   QModelIndex indexFromPath(FmPath* filePath);
-  QGraphicsItem* getGifItem();
+  QGraphicsItem* getGraphicsItem();
 
   // GObject related signal handers and callbacks
   static void _onFolderLoaded(FmFolder* folder, MainWindow* _this) {

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -221,7 +221,7 @@
     <string>Zoom &amp;In</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl++</string>
+    <string>Ctrl+=</string>
    </property>
   </action>
   <action name="actionZoomOut">
@@ -287,6 +287,9 @@
    </property>
    <property name="text">
     <string>Original Size</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+0</string>
    </property>
   </action>
   <action name="actionZoomFit">


### PR DESCRIPTION
Fixes https://github.com/lxde/lximage-qt/issues/49 by using QGraphicsSvgItem.

Also the zoom-in shortcut is fixed and a shortcut is added for zooming to the original size.

BTW, this PR also enables lximage-qt to show SVG animations as far as they're supported by Qt.