### PR TITLE
Quieten compiler warning

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -35,8 +35,8 @@ static const char* ifaceName = "org.lxde.LxImage.Application";
 
 Application::Application(int& argc, char** argv):
   QApplication(argc, argv),
-  windowCount_(0),
-  libFm() {
+  libFm(),
+  windowCount_(0) {
   setApplicationVersion(LXIMAGE_VERSION);
 }
 

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -35,13 +35,13 @@ namespace LxImage {
 
 ImageView::ImageView(QWidget* parent):
   QGraphicsView(parent),
-  imageItem_(new QGraphicsRectItem()),
   scene_(new QGraphicsScene(this)),
+  imageItem_(new QGraphicsRectItem()),
   gifMovie_(nullptr),
-  autoZoomFit_(false),
   cacheTimer_(nullptr),
   cursorTimer_(nullptr),
   scaleFactor_(1.0),
+  autoZoomFit_(false),
   isSVG(false) {
 
   setViewportMargins(0, 0, 0, 0);

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -35,7 +35,7 @@ Job::~Job() {
 
 // This is called from the worker thread, not main thread
 gboolean Job::_jobThread(GIOSchedulerJob* job, GCancellable* cancellable, Job* pThis) {
-  bool ret = pThis->run();
+  pThis->run();
   // do final step in the main thread
   if(!g_cancellable_is_cancelled(pThis->cancellable_))
     g_io_scheduler_job_send_to_mainloop(job, GSourceFunc(_finish), pThis, NULL);

--- a/src/loadimagejob.cpp
+++ b/src/loadimagejob.cpp
@@ -29,8 +29,8 @@ using namespace LxImage;
 
 LoadImageJob::LoadImageJob(MainWindow* window, FmPath* filePath):
   Job(),
-  path_(fm_path_ref(filePath)),
-  mainWindow_(window) {
+  mainWindow_(window),
+  path_(fm_path_ref(filePath)) {
 }
 
 LoadImageJob::~LoadImageJob() {
@@ -71,7 +71,7 @@ bool LoadImageJob::run() {
           // use libexif to extract additional info embedded in jpeg files
           ExifLoader *exif_loader = exif_loader_new();
           // write image data to exif loader
-          int ret = exif_loader_write(exif_loader, (unsigned char*)imageBuffer.data().constData(), (unsigned int)imageBuffer.size());
+          exif_loader_write(exif_loader, (unsigned char*)imageBuffer.data().constData(), (unsigned int)imageBuffer.size());
           ExifData *exif_data = exif_loader_get_data(exif_loader);
           exif_loader_unref(exif_loader);
           if(exif_data) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,21 +46,21 @@ using namespace LxImage;
 
 MainWindow::MainWindow():
   QMainWindow(),
-  currentFile_(nullptr),
+  contextMenu_(new QMenu(this)),
   slideShowTimer_(nullptr),
+  image_(),
+  currentFile_(nullptr),
   // currentFileInfo_(nullptr),
-  loadJob_(nullptr),
-  saveJob_(nullptr),
+  imageModified_(false),
   folder_(nullptr),
   folderPath_(nullptr),
   folderModel_(new Fm::FolderModel()),
   proxyModel_(new Fm::ProxyFolderModel()),
   modelFilter_(new ModelFilter()),
-  imageModified_(false),
-  contextMenu_(new QMenu(this)),
   thumbnailsDock_(nullptr),
   thumbnailsView_(nullptr),
-  image_() {
+  loadJob_(nullptr),
+  saveJob_(nullptr) {
 
   setAttribute(Qt::WA_DeleteOnClose); // FIXME: check if current image is saved before close
 

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -96,8 +96,6 @@ static void findIconThemesInDir(QHash<QString, QString>& iconThemes, QString dir
 }
 
 void PreferencesDialog::initIconThemes(Settings& settings) {
-  Application* app = static_cast<Application*>(qApp);
-
   // check if auto-detection is done (for example, from xsettings)
   if(settings.useFallbackIconTheme()) { // auto-detection failed
     // load xdg icon themes and select the current one

--- a/src/saveimagejob.cpp
+++ b/src/saveimagejob.cpp
@@ -28,8 +28,8 @@ using namespace LxImage;
 
 SaveImageJob::SaveImageJob(MainWindow* window, FmPath* filePath):
   Job(),
-  path_(fm_path_ref(filePath)),
   mainWindow_(window),
+  path_(fm_path_ref(filePath)),
   image_(window->image()) {
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -27,11 +27,11 @@ using namespace LxImage;
 Settings::Settings():
   useFallbackIconTheme_(QIcon::themeName().isEmpty() || QIcon::themeName() == "hicolor"),
   bgColor_(255, 255, 255),
+  fullScreenBgColor_(0, 0, 0),
   showThumbnails_(false),
   showSidePane_(false),
-  fullScreenBgColor_(0, 0, 0),
-  fallbackIconTheme_("oxygen"),
   slideShowInterval_(5),
+  fallbackIconTheme_("oxygen"),
   fixedWindowWidth_(640),
   fixedWindowHeight_(480),
   lastWindowWidth_(640),
@@ -49,7 +49,7 @@ bool Settings::load() {
   fullScreenBgColor_ = settings.value("fullScreenBgColor", fullScreenBgColor_).value<QColor>();
   // showThumbnails_;
   // showSidePane_;
-  int slideShowInterval_ = settings.value("slideShowInterval", slideShowInterval_).toInt();
+  slideShowInterval_ = settings.value("slideShowInterval", slideShowInterval_).toInt();
 
   settings.beginGroup("Window");
   fixedWindowWidth_ = settings.value("FixedWidth", 640).toInt();


### PR DESCRIPTION
Thanks to, https://github.com/lxde/lximage-qt/pull/58/commits/8c52c8ddf0a14369d6b0f53e7672992294d2d287, a problem is also found and fixed.

A warning related to `g_io_scheduler_job_send_to_mainloop()` remains. I think @PCMan might fix it better than I could.