### PR TITLE
changed timeout for image cache rebuilding timer from 200ms to immediate

### DIFF
--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -322,7 +322,7 @@ void ImageView::queueGenerateCache() {
     connect(cacheTimer_, &QTimer::timeout, this, &ImageView::generateCache);
   }
   if(cacheTimer_)
-    cacheTimer_->start(200); // restart the timer
+    cacheTimer_->start(); // restart the timer
 }
 
 // really generate the cache


### PR DESCRIPTION
Now the downsampled image pops immediately, without displaying the coarse version for the first 200ms. Not sure why delay was put there in the first place.