### PR TITLE
[MRG] Display first image when loading a directory

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -148,7 +148,7 @@ void Application::newWindow(QStringList files) {
   else {
     Q_FOREACH(QString fileName, files) {
       window = createWindow();
-      window->openImageFile(fileName);
+      window->openPath(fileName);
 
       window->resize(settings_.windowWidth(), settings_.windowHeight());
       if(settings_.windowMaximized())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -345,7 +345,7 @@ void MainWindow::on_actionOpenFile_triggered() {
 void MainWindow::on_actionOpenDirectory_triggered() {
   QString directory = openDirectory();
   if(!directory.isEmpty()) {
-    openImageFile(directory);
+    openImageDirectory(directory);
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -301,38 +301,38 @@ QString MainWindow::saveFileName(QString defaultName) {
 
 QStringList MainWindow::getImageFormatsFilters()
 {
-    QList<QByteArray> formats = QImageReader::supportedImageFormats();
-    QStringList formatsFilters;
-    for (const QByteArray& format: formats) {
-        formatsFilters << QString("*.") + format;
-    }
-    return formatsFilters;
+  QList<QByteArray> formats = QImageReader::supportedImageFormats();
+  QStringList formatsFilters;
+  for (const QByteArray& format: formats) {
+    formatsFilters << QString("*.") + format;
+  }
+  return formatsFilters;
 }
 
 QString MainWindow::findFirstImageOfDir(QString dirname)
 {
-    auto formatsFilters = getImageFormatsFilters();
+  auto formatsFilters = getImageFormatsFilters();
 
-    QDir dir(dirname);
-    dir.setNameFilters(formatsFilters);
-    dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
-    dir.setSorting(QDir::NoSort);
+  QDir dir(dirname);
+  dir.setNameFilters(formatsFilters);
+  dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
+  dir.setSorting(QDir::NoSort);
 
-    auto files = dir.entryList();
+  auto files = dir.entryList();
 
-    if (files.empty()) {
-        return QString();
-    }
+  if (files.empty()) {
+    return QString();
+  }
 
-    QCollator collator;
-    collator.setNumericMode(true);
-    std::partial_sort(files.begin(), files.begin() + 1, files.end(),
-            [&collator](const QString& file1, const QString& file2)
-            {
-                return collator.compare(file1, file2) < 0;
-            });
+  QCollator collator;
+  collator.setNumericMode(true);
+  std::partial_sort(files.begin(), files.begin() + 1, files.end(),
+          [&collator](const QString& file1, const QString& file2)
+          {
+              return collator.compare(file1, file2) < 0;
+          });
 
-    return dir.absoluteFilePath(files.first());
+  return dir.absoluteFilePath(files.first());
 }
 
 void MainWindow::on_actionOpenFile_triggered() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -257,6 +257,12 @@ QString MainWindow::openFileName() {
   return fileName;
 }
 
+QString MainWindow::openDirectory() {
+  QString directory = QFileDialog::getExistingDirectory(this,
+          tr("Open directory"), QString());
+  return directory;
+}
+
 // popup a file dialog and retrieve the selected image file name
 QString MainWindow::saveFileName(QString defaultName) {
   QString filterStr;
@@ -304,6 +310,13 @@ void MainWindow::on_actionOpenFile_triggered() {
   QString fileName = openFileName();
   if(!fileName.isEmpty()) {
     openImageFile(fileName);
+  }
+}
+
+void MainWindow::on_actionOpenDirectory_triggered() {
+  QString directory = openDirectory();
+  if(!directory.isEmpty()) {
+    openImageFile(directory);
   }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -45,7 +45,6 @@
 #include <libfm-qt/folderview.h>
 #include <libfm-qt/filepropsdialog.h>
 #include <libfm-qt/fileoperation.h>
-#include <libfm-qt/fileinfo.h>
 
 using namespace LxImage;
 
@@ -198,10 +197,7 @@ void MainWindow::openImageFile(QString fileName) {
     fm_path_unref(path);
     return;
   }
-  Fm::FileInfo info = Fm::FileInfo::newFromNativeFile(nullptr,
-                                                      qPrintable(fileName),
-                                                      nullptr);
-  if (info.isDir()) {
+  if (QFileInfo(fileName).isDir()) {
       QString imageString = findFirstImageOfDir(fileName);
       FmPath* imagePath = fm_path_new_for_str(qPrintable(imageString));
       loadImage(imagePath);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -313,7 +313,7 @@ QString MainWindow::findFirstImageOfDir(QString dirname)
 
     QCollator collator;
     collator.setNumericMode(true);
-    std::sort(files.begin(), files.end(),
+    std::partial_sort(files.begin(), files.begin() + 1, files.end(),
             [&collator](const QString& file1, const QString& file2)
             {
                 return collator.compare(file1, file2) < 0;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -190,24 +190,37 @@ void MainWindow::onFolderLoaded(FmFolder* folder) {
   }
 }
 
+void MainWindow::openPath(QString path) {
+  if (QFileInfo(path).isDir()) {
+    openImageDirectory(path);
+  } else {
+    openImageFile(path);
+  }
+}
+
+void MainWindow::openImageDirectory(const QString& dir) {
+  QString imageString = findFirstImageOfDir(dir);
+  FmPath* imagePath = fm_path_new_for_str(qPrintable(imageString));
+  loadImage(imagePath);
+  fm_path_unref(imagePath);
+  FmPath* fmDir = fm_path_new_for_str(qPrintable(dir));
+  loadFolder(fmDir);
+  fm_path_unref(fmDir);
+}
+
+bool MainWindow::isFileLoaded(FmPath* path) {
+  return currentFile_ && fm_path_equal(currentFile_, path);
+}
+
 void MainWindow::openImageFile(QString fileName) {
   FmPath* path = fm_path_new_for_str(qPrintable(fileName));
-  if(currentFile_ && fm_path_equal(currentFile_, path)) {
-    // the same file! do not load it again
+  if (isFileLoaded(path)) {
     fm_path_unref(path);
     return;
   }
-  if (QFileInfo(fileName).isDir()) {
-      QString imageString = findFirstImageOfDir(fileName);
-      FmPath* imagePath = fm_path_new_for_str(qPrintable(imageString));
-      loadImage(imagePath);
-      fm_path_unref(imagePath);
-      loadFolder(path);
-  } else {
-      // load the image file asynchronously
-      loadImage(path);
-      loadFolder(fm_path_get_parent(path));
-  }
+  // load the image file asynchronously
+  loadImage(path);
+  loadFolder(fm_path_get_parent(path));
   fm_path_unref(path);
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -75,6 +75,7 @@ protected:
   void loadFolder(FmPath* newFolderPath);
   QString openFileName();
   QString saveFileName(QString defaultName = QString());
+  QString firstImageOfDir(QString dirname);
   virtual void changeEvent(QEvent * event);
   virtual void resizeEvent(QResizeEvent *event);
   virtual void closeEvent(QCloseEvent *event);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -75,6 +75,7 @@ protected:
   void loadFolder(FmPath* newFolderPath);
   QString openFileName();
   QString saveFileName(QString defaultName = QString());
+  QString openDirectory();
   QString firstImageOfDir(QString dirname);
   virtual void changeEvent(QEvent * event);
   virtual void resizeEvent(QResizeEvent *event);
@@ -88,6 +89,7 @@ private Q_SLOTS:
   void on_actionAbout_triggered();
 
   void on_actionOpenFile_triggered();
+  void on_actionOpenDirectory_triggered();
   void on_actionNewWindow_triggered();
   void on_actionSave_triggered();
   void on_actionSaveAs_triggered();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -54,7 +54,7 @@ public:
   MainWindow();
   virtual ~MainWindow();
 
-  void openImageFile(QString fileName);
+  void openPath(QString fileName);
 
   QImage image() const {
     return image_;
@@ -75,6 +75,9 @@ protected:
   void loadFolder(FmPath* newFolderPath);
   QString openFileName();
   QString saveFileName(QString defaultName = QString());
+  void openImageDirectory(const QString& path);
+  bool isFileLoaded(FmPath* path);
+  void openImageFile(QString fileName);
   QString openDirectory();
   QStringList getImageFormatsFilters();
   QString findFirstImageOfDir(QString dirname);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -76,7 +76,8 @@ protected:
   QString openFileName();
   QString saveFileName(QString defaultName = QString());
   QString openDirectory();
-  QString firstImageOfDir(QString dirname);
+  QStringList getImageFormatsFilters();
+  QString findFirstImageOfDir(QString dirname);
   virtual void changeEvent(QEvent * event);
   virtual void resizeEvent(QResizeEvent *event);
   virtual void closeEvent(QCloseEvent *event);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -56,6 +56,7 @@
     </property>
     <addaction name="actionNewWindow"/>
     <addaction name="actionOpenFile"/>
+    <addaction name="actionOpenDirectory"/>
     <addaction name="actionScreenshot"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
@@ -452,6 +453,17 @@
   <action name="actionFileProperties">
    <property name="text">
     <string>File Properties</string>
+   </property>
+  </action>
+  <action name="actionOpenDirectory">
+   <property name="icon">
+    <iconset theme="document-open"/>
+   </property>
+   <property name="text">
+    <string>Open &amp;Directory</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This PR addresses https://github.com/lxde/lxqt/issues/1117.

Goal: When loading a directory from CLI or from a dialog, display the first image of the directory.
- [x] Load directory from CLI.
- [x] Load directory from Dialog.

The current implementation uses QDir for listing the files in a directory. Is it OK with the project policy? Or should one use libfm-qt functions where possible? 
