### PR TITLE
File and folder DND

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(lximage-qt_SRCS
     saveimagejob.cpp
     screenshotdialog.cpp
     settings.cpp
+    graphicsscene.cpp
 )
 
 qt5_add_dbus_adaptor(lximage-qt_SRCS

--- a/src/graphicsscene.cpp
+++ b/src/graphicsscene.cpp
@@ -1,0 +1,48 @@
+/*
+ * <one line to give the library's name and an idea of what it does.>
+ * Copyright (C) 2014  <copyright holder> <email>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "graphicsscene.h"
+#include <QMimeData>
+#include <QUrl>
+
+namespace LxImage {
+
+GraphicsScene::GraphicsScene(QObject *parent):
+  QGraphicsScene (parent) {
+}
+
+void GraphicsScene::dragEnterEvent(QGraphicsSceneDragDropEvent *event) {
+  if(event->mimeData()->hasUrls())
+    event->acceptProposedAction();
+}
+
+void GraphicsScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event) {
+  if(event->mimeData()->hasUrls())
+    event->acceptProposedAction();
+}
+
+void GraphicsScene::dropEvent(QGraphicsSceneDragDropEvent* event) {
+  QList<QUrl> urlList = event->mimeData()->urls();
+  if(!urlList.isEmpty())
+    Q_EMIT fileDropped(urlList.first().toLocalFile());
+  event->acceptProposedAction();
+}
+
+}

--- a/src/graphicsscene.h
+++ b/src/graphicsscene.h
@@ -1,0 +1,46 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  <copyright holder> <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef LXIMAGE_GRAPHICSSCENE_H
+#define LXIMAGE_GRAPHICSSCENE_H
+
+#include <QGraphicsScene>
+#include <QGraphicsSceneDragDropEvent>
+
+namespace LxImage {
+
+class GraphicsScene : public QGraphicsScene
+{
+  Q_OBJECT
+
+public:
+  GraphicsScene(QObject *parent = 0);
+
+protected:
+  virtual void dragEnterEvent(QGraphicsSceneDragDropEvent *event);
+  virtual void dragMoveEvent(QGraphicsSceneDragDropEvent *event);
+  virtual void dropEvent(QGraphicsSceneDragDropEvent* event);
+
+Q_SIGNALS:
+  void fileDropped(const QString file);
+};
+
+}
+
+#endif // LXIMAGE_GRAPHICSSCENE_H

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -35,7 +35,7 @@ namespace LxImage {
 
 ImageView::ImageView(QWidget* parent):
   QGraphicsView(parent),
-  scene_(new QGraphicsScene(this)),
+  scene_(new GraphicsScene(this)),
   imageItem_(new QGraphicsRectItem()),
   gifMovie_(nullptr),
   cacheTimer_(nullptr),
@@ -49,6 +49,7 @@ ImageView::ImageView(QWidget* parent):
   setLineWidth(0);
 
   setScene(scene_);
+  connect(scene_, &GraphicsScene::fileDropped, this, &ImageView::onFileDropped);
   imageItem_->hide();
   imageItem_->setPen(QPen(Qt::NoPen)); // remove the border
   scene_->addItem(imageItem_);
@@ -68,6 +69,9 @@ ImageView::~ImageView() {
   }
 }
 
+void ImageView::onFileDropped(const QString file) {
+    Q_EMIT fileDropped(file);
+}
 
 void ImageView::wheelEvent(QWheelEvent* event) {
   int delta = event->delta();

--- a/src/imageview.h
+++ b/src/imageview.h
@@ -21,6 +21,7 @@
 #ifndef LXIMAGE_IMAGEVIEW_H
 #define LXIMAGE_IMAGEVIEW_H
 
+#include "graphicsscene.h"
 #include <QGraphicsView>
 #include <QGraphicsScene>
 #include <QGraphicsRectItem>
@@ -71,6 +72,9 @@ public:
   // if set to true, hides the cursor after 3s of inactivity
   void hideCursor(bool enable);
 
+Q_SIGNALS:
+  void fileDropped(const QString file);
+
 protected:
   virtual void wheelEvent(QWheelEvent* event);
   virtual void mouseDoubleClickEvent(QMouseEvent* event);
@@ -87,11 +91,12 @@ private:
   QRect sceneToViewport(const QRectF& rect);
 
 private Q_SLOTS:
+  void onFileDropped(const QString file);
   void generateCache();
   void blankCursor();
 
 private:
-  QGraphicsScene* scene_; // the topmost container of all graphic items
+  GraphicsScene* scene_; // the topmost container of all graphic items
   QGraphicsRectItem* imageItem_; // the rect item used to draw the image
   QImage image_; // image to show
   QMovie *gifMovie_; // gif animation to show (should be deleted explicitly)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -83,6 +83,8 @@ MainWindow::MainWindow():
   ui.view->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(ui.view, &QWidget::customContextMenuRequested, this, &MainWindow::onContextMenu);
 
+  connect(ui.view, &ImageView::fileDropped, this, &MainWindow::onFileDropped);
+
   // install an event filter on the image view
   ui.view->installEventFilter(this);
   ui.view->setBackgroundBrush(QBrush(settings.bgColor()));
@@ -988,4 +990,8 @@ void MainWindow::onThumbnailSelChanged(const QItemSelection& selected, const QIt
         loadImage(fm_file_info_get_path(file), index);
     }
   }
+}
+
+void MainWindow::onFileDropped(const QString path) {
+    openImageFile(path);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -123,6 +123,8 @@ private Q_SLOTS:
 
   void onThumbnailSelChanged(const QItemSelection & selected, const QItemSelection & deselected);
 
+  void onFileDropped(const QString path);
+
 private:
   void onFolderLoaded(FmFolder* folder);
   void updateUI();


### PR DESCRIPTION
Fixes https://github.com/lxde/lximage-qt/issues/69.

A file/folder can be dropped into lximage-qt's view and it will be opened if it is/contains a valid image.