### PR TITLE
Drops Qt5Core_VERSION_STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(Qt5Svg REQUIRED QUIET)
 find_package(fm-qt REQUIRED QUIET)
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(Exif REQUIRED QUIET)
-message(STATUS "Building with Qt ${Qt5Core_VERSION_STRING}")
+message(STATUS "Building with Qt ${Qt5Core_VERSION}")
 
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
 


### PR DESCRIPTION
Use Qt5Core_VERSION. Qt5Core_VERSION_STRING is a compatibility variable and
it was removed in Qt 5.9 release.