### PR TITLE
Don't use hardcoded install dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ add_executable(lximage-qt
 )
 
 add_definitions(
-    -DLXIMAGE_DATA_DIR="${CMAKE_INSTALL_PREFIX}/share/lximage-qt"
+    -DLXIMAGE_DATA_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/lximage-qt"
     -DLXIMAGE_VERSION="${LXIMAGE_VERSION}"
 )
 


### PR DESCRIPTION
This way we don't make assumptions about install dirs. And we give the
packager the ability to override CMAKE_INSTALL_DATAROOTDIR.