### PR TITLE
Add support for uploading files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 find_package(Qt5Widgets REQUIRED)
+find_package(Qt5Network REQUIRED)
 find_package(Qt5DBus REQUIRED)
 find_package(Qt5PrintSupport REQUIRED)
 find_package(Qt5X11Extras REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,12 @@ set(lximage-qt_SRCS
     screenshotselectareagraphicsview.cpp
     settings.cpp
     graphicsscene.cpp
+
+    upload/imgurprovider.cpp
+    upload/imgurupload.cpp
+    upload/provider.cpp
+    upload/upload.cpp
+    upload/uploaddialog.cpp
 )
 
 qt5_add_dbus_adaptor(lximage-qt_SRCS
@@ -37,6 +43,8 @@ set(lximage-qt_UIS
     mainwindow.ui
     preferencesdialog.ui
     screenshotdialog.ui
+
+    upload/uploaddialog.ui
 )
 qt5_wrap_ui(lximage-qt_UI_H ${lximage-qt_UIS})
 
@@ -80,7 +88,7 @@ add_definitions(
     -DLXIMAGE_VERSION="${LXIMAGE_VERSION}"
 )
 
-set(QT_LIBRARIES Qt5::Widgets Qt5::Core Qt5::DBus Qt5::PrintSupport Qt5::X11Extras Qt5::Svg)
+set(QT_LIBRARIES Qt5::Widgets Qt5::Network Qt5::Core Qt5::DBus Qt5::PrintSupport Qt5::X11Extras Qt5::Svg)
 
 target_link_libraries(lximage-qt
     fm-qt

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -45,6 +45,8 @@
 #include <libfm-qt/fileoperation.h>
 #include <libfm-qt/folderitemdelegate.h>
 
+#include "upload/uploaddialog.h"
+
 using namespace LxImage;
 
 MainWindow::MainWindow():
@@ -730,6 +732,13 @@ void MainWindow::on_actionPaste_triggered() {
   if(!image.isNull()) {
     pasteImage(image);
   }
+}
+
+void MainWindow::on_actionUpload_triggered()
+{
+    if (currentFile_.isValid()) {
+        UploadDialog(this, currentFile_.localPath().get()).exec();
+    }
 }
 
 void MainWindow::on_actionFlipVertical_triggered() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -103,6 +103,7 @@ private Q_SLOTS:
   void on_actionFlipHorizontal_triggered();
   void on_actionCopy_triggered();
   void on_actionPaste_triggered();
+  void on_actionUpload_triggered();
 
   void on_actionShowThumbnails_triggered(bool checked);
   void on_actionFullScreen_triggered(bool checked);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -108,6 +108,8 @@
     <addaction name="actionCopy"/>
     <addaction name="actionPaste"/>
     <addaction name="separator"/>
+    <addaction name="actionUpload"/>
+    <addaction name="separator"/>
     <addaction name="actionPreferences"/>
    </widget>
    <addaction name="menu_File"/>
@@ -464,6 +466,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>
+   </property>
+  </action>
+  <action name="actionUpload">
+   <property name="icon">
+    <iconset theme="upload-media"/>
+   </property>
+   <property name="text">
+    <string>Upload</string>
+   </property>
+   <property name="toolTip">
+    <string>Upload the image</string>
    </property>
   </action>
  </widget>

--- a/src/upload/imgurprovider.cpp
+++ b/src/upload/imgurprovider.cpp
@@ -1,0 +1,42 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+#include "imgurprovider.h"
+#include "imgurupload.h"
+
+using namespace LxImage;
+
+const QUrl gUploadURL("https://api.imgur.com/3/upload.json");
+const QByteArray gAuthHeader = "Client-ID 63ff047cd8bcf9e";
+const QByteArray gTypeHeader = "application/x-www-form-urlencoded";
+
+Upload *ImgurProvider::upload(QIODevice *device)
+{
+    // Create the request with the correct HTTP headers
+    QNetworkRequest request(gUploadURL);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, gTypeHeader);
+    request.setRawHeader("Authorization", gAuthHeader);
+
+    // Start the request and wrap it in an ImgurUpload
+    return new ImgurUpload(mManager.post(request, device));
+}

--- a/src/upload/imgurprovider.cpp
+++ b/src/upload/imgurprovider.cpp
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/imgurprovider.cpp
+++ b/src/upload/imgurprovider.cpp
@@ -38,5 +38,5 @@ Upload *ImgurProvider::upload(QIODevice *device)
     request.setRawHeader("Authorization", gAuthHeader);
 
     // Start the request and wrap it in an ImgurUpload
-    return new ImgurUpload(mManager.post(request, device));
+    return new ImgurUpload(sManager.post(request, device));
 }

--- a/src/upload/imgurprovider.h
+++ b/src/upload/imgurprovider.h
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/imgurprovider.h
+++ b/src/upload/imgurprovider.h
@@ -1,0 +1,47 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef LXIMAGE_IMGURPROVIDER_H
+#define LXIMAGE_IMGURPROVIDER_H
+
+#include <QNetworkAccessManager>
+
+#include "provider.h"
+
+namespace LxImage {
+
+/**
+ * @brief Create uploads to Imgur's API
+ */
+class ImgurProvider : public Provider
+{
+    Q_OBJECT
+
+public:
+
+    virtual Upload *upload(QIODevice *device);
+
+private:
+
+    QNetworkAccessManager mManager;
+};
+
+}
+
+#endif // LXIMAGE_IMGURPROVIDER_H

--- a/src/upload/imgurprovider.h
+++ b/src/upload/imgurprovider.h
@@ -20,8 +20,6 @@
 #ifndef LXIMAGE_IMGURPROVIDER_H
 #define LXIMAGE_IMGURPROVIDER_H
 
-#include <QNetworkAccessManager>
-
 #include "provider.h"
 
 namespace LxImage {
@@ -36,10 +34,6 @@ class ImgurProvider : public Provider
 public:
 
     virtual Upload *upload(QIODevice *device);
-
-private:
-
-    QNetworkAccessManager mManager;
 };
 
 }

--- a/src/upload/imgurupload.cpp
+++ b/src/upload/imgurupload.cpp
@@ -1,0 +1,52 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "imgurupload.h"
+
+using namespace LxImage;
+
+ImgurUpload::ImgurUpload(QNetworkReply *reply)
+    : Upload(reply)
+{
+}
+
+void ImgurUpload::processReply(const QByteArray &data)
+{
+    // Obtain the root object from the JSON response
+    QJsonObject object(QJsonDocument::fromJson(data).object());
+
+    // Attempt to retrieve the value for "success" and "data->link"
+    bool success = object.value("success").toBool();
+    QJsonObject dataObject = object.value("data").toObject();
+    QString dataLink = dataObject.value("link").toString();
+    QString dataError = dataObject.value("error").toString();
+
+    // Ensure that "success" is true & link is valid, otherwise throw an error
+    if (!success || dataLink.isNull()) {
+        if (dataError.isNull()) {
+            dataError = tr("unknown error response");
+        }
+        Q_EMIT error(dataError);
+    } else {
+        Q_EMIT completed(dataLink);
+    }
+}

--- a/src/upload/imgurupload.cpp
+++ b/src/upload/imgurupload.cpp
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/imgurupload.h
+++ b/src/upload/imgurupload.h
@@ -1,0 +1,43 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef LXIMAGE_IMGURUPLOAD_H
+#define LXIMAGE_IMGURUPLOAD_H
+
+#include "upload.h"
+
+namespace LxImage {
+
+/**
+ * @brief Process uploads to Imgur's API
+ */
+class ImgurUpload : public Upload
+{
+    Q_OBJECT
+
+public:
+
+    explicit ImgurUpload(QNetworkReply *reply);
+
+    virtual void processReply(const QByteArray &data);
+};
+
+}
+
+#endif // LXIMAGE_IMGURUPLOAD_H

--- a/src/upload/imgurupload.h
+++ b/src/upload/imgurupload.h
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/provider.cpp
+++ b/src/upload/provider.cpp
@@ -18,3 +18,7 @@
 */
 
 #include "provider.h"
+
+using namespace LxImage;
+
+QNetworkAccessManager Provider::sManager;

--- a/src/upload/provider.cpp
+++ b/src/upload/provider.cpp
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/provider.cpp
+++ b/src/upload/provider.cpp
@@ -1,0 +1,20 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "provider.h"

--- a/src/upload/provider.h
+++ b/src/upload/provider.h
@@ -1,0 +1,49 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef LXIMAGE_PROVIDER_H
+#define LXIMAGE_PROVIDER_H
+
+#include <QIODevice>
+#include <QObject>
+
+namespace LxImage {
+
+class Upload;
+
+/**
+ * @brief Base class for providers
+ */
+class Provider : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * @brief Upload the provided data
+     * @param device reader for uploaded data from
+     * @return newly created upload
+     */
+    virtual Upload *upload(QIODevice *device) = 0;
+};
+
+}
+
+#endif // LXIMAGE_PROVIDER_H

--- a/src/upload/provider.h
+++ b/src/upload/provider.h
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/provider.h
+++ b/src/upload/provider.h
@@ -21,6 +21,7 @@
 #define LXIMAGE_PROVIDER_H
 
 #include <QIODevice>
+#include <QNetworkAccessManager>
 #include <QObject>
 
 namespace LxImage {
@@ -42,6 +43,10 @@ public:
      * @return newly created upload
      */
     virtual Upload *upload(QIODevice *device) = 0;
+
+protected:
+
+    static QNetworkAccessManager sManager;
 };
 
 }

--- a/src/upload/upload.cpp
+++ b/src/upload/upload.cpp
@@ -1,0 +1,57 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "upload.h"
+
+using namespace LxImage;
+
+Upload::Upload(QNetworkReply *reply)
+    : mReply(reply)
+{
+    // Reparent the reply to this object
+    mReply->setParent(this);
+
+    // Emit progress() when upload progress changes
+    connect(mReply, &QNetworkReply::uploadProgress, [this](qint64 bytesSent, qint64 bytesTotal) {
+        Q_EMIT progress(static_cast<int>(
+            static_cast<double>(bytesSent) / static_cast<double>(bytesTotal) * 100.0
+        ));
+    });
+
+    // Emit error() when a socket error occurs
+    connect(mReply, static_cast<void(QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), [this](QNetworkReply::NetworkError) {
+        Q_EMIT error(mReply->errorString());
+    });
+
+    // Process the request when it finishes
+    connect(mReply, &QNetworkReply::finished, [this]() {
+        if (mReply->error() == QNetworkReply::NoError) {
+            processReply(mReply->readAll());
+        }
+    });
+
+    // Emit finished() when completed() or error() is emitted
+    connect(this, &Upload::completed, this, &Upload::finished);
+    connect(this, &Upload::error, this, &Upload::finished);
+}
+
+void Upload::abort()
+{
+    mReply->abort();
+}

--- a/src/upload/upload.cpp
+++ b/src/upload/upload.cpp
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/upload.h
+++ b/src/upload/upload.h
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  PCMan <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/upload.h
+++ b/src/upload/upload.h
@@ -1,0 +1,96 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  PCMan <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef LXIMAGE_UPLOAD_H
+#define LXIMAGE_UPLOAD_H
+
+#include <QNetworkReply>
+#include <QObject>
+
+namespace LxImage {
+
+/**
+ * @brief Base class for uploads
+ */
+class Upload : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * @brief Create an upload
+     * @param reply network reply
+     *
+     * The upload will assume ownership of the network reply and connect to its
+     * signals, emitting uploadError() when something goes wrong.
+     */
+    explicit Upload(QNetworkReply *reply);
+
+    /**
+     * @brief Abort the upload
+     */
+    void abort();
+
+Q_SIGNALS:
+
+    /**
+     * @brief Indicate that upload progress has changed
+     * @param value new progress value
+     */
+    void progress(int value);
+
+    /**
+     * @brief Indicate that the upload completed
+     * @param url new URL of the upload
+     */
+    void completed(const QString &url);
+
+    /**
+     * @brief Indicate that an error occurred
+     * @param message description of the error
+     */
+    void error(const QString &message);
+
+    /**
+     * @brief Indicate that the upload finished
+     *
+     * This signal is emitted after either completed() or error().
+     */
+    void finished();
+
+protected:
+
+    /**
+     * @brief Process the data from the reply
+     * @param data content from the reply
+     *
+     * This method should parse the data and either emit the completed() or
+     * error() signal.
+     */
+    virtual void processReply(const QByteArray &data) = 0;
+
+private:
+
+    QNetworkReply *mReply;
+};
+
+}
+
+#endif // LXIMAGE_UPLOAD_H

--- a/src/upload/uploaddialog.cpp
+++ b/src/upload/uploaddialog.cpp
@@ -1,0 +1,137 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  <copyright holder> <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <QComboBox>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QVariant>
+
+#include "imgurprovider.h"
+#include "provider.h"
+#include "upload.h"
+#include "uploaddialog.h"
+
+using namespace LxImage;
+
+ImgurProvider gImgurProvider;
+
+UploadDialog::UploadDialog(QWidget *parent, const QString &filename)
+    : QDialog(parent),
+      mFile(filename),
+      mState(SelectProvider),
+      mUpload(nullptr)
+{
+    ui.setupUi(this);
+
+    // Populate the list of providers
+    ui.providerComboBox->addItem(tr("Imgur"), QVariant::fromValue(&gImgurProvider));
+
+    updateUi();
+}
+
+void UploadDialog::on_actionButton_clicked()
+{
+    switch (mState) {
+    case SelectProvider:
+        start();
+        break;
+    case UploadInProgress:
+        mUpload->abort();
+        break;
+    case Completed:
+        accept();
+        break;
+    }
+}
+
+void UploadDialog::start()
+{
+    // Attempt to open the file
+    if (!mFile.open(QIODevice::ReadOnly)) {
+        showError(mFile.errorString());
+        return;
+    }
+
+    // Retrieve the selected provider
+    Provider *provider = ui.providerComboBox->itemData(
+        ui.providerComboBox->currentIndex()
+    ).value<Provider*>();
+
+    // Create the upload
+    mUpload = provider->upload(&mFile);
+
+    // Update the progress bar as the upload progresses
+    connect(mUpload, &Upload::progress, ui.progressBar, &QProgressBar::setValue);
+
+    // If the request completes, show the link to the user
+    connect(mUpload, &Upload::completed, [this](const QString &url) {
+        ui.linkLineEdit->setText(url);
+
+        mState = Completed;
+        updateUi();
+    });
+
+    // If the request fails, show an error
+    connect(mUpload, &Upload::error, [this](const QString &message) {
+        showError(message);
+    });
+
+    // Destroy the upload when it completes
+    connect(mUpload, &Upload::finished, [this]() {
+        mUpload->deleteLater();
+        mUpload = nullptr;
+    });
+
+    mState = UploadInProgress;
+    updateUi();
+}
+
+void UploadDialog::updateUi()
+{
+    // Show the appropriate control given the current state
+    ui.providerComboBox->setVisible(mState == SelectProvider);
+    ui.progressBar->setVisible(mState == UploadInProgress);
+    ui.linkLineEdit->setVisible(mState == Completed);
+
+    // Reset the progress bar to zero
+    ui.progressBar->setValue(0);
+
+    // Set the correct button text
+    switch (mState) {
+    case SelectProvider:
+        ui.actionButton->setText(tr("Start"));
+        break;
+    case UploadInProgress:
+        ui.actionButton->setText(tr("Stop"));
+        break;
+    case Completed:
+        ui.actionButton->setText(tr("Close"));
+        break;
+    }
+}
+
+void UploadDialog::showError(const QString &message)
+{
+    QMessageBox::critical(this, tr("Error"), message);
+
+    mState = SelectProvider;
+    updateUi();
+}

--- a/src/upload/uploaddialog.cpp
+++ b/src/upload/uploaddialog.cpp
@@ -35,8 +35,8 @@ ImgurProvider gImgurProvider;
 
 UploadDialog::UploadDialog(QWidget *parent, const QString &filename)
     : QDialog(parent),
-      mFile(filename),
       mState(SelectProvider),
+      mFile(filename),
       mUpload(nullptr)
 {
     ui.setupUi(this);

--- a/src/upload/uploaddialog.cpp
+++ b/src/upload/uploaddialog.cpp
@@ -96,6 +96,7 @@ void UploadDialog::start()
 
     // Destroy the upload when it completes
     connect(mUpload, &Upload::finished, [this]() {
+        mFile.close();
         mUpload->deleteLater();
         mUpload = nullptr;
     });

--- a/src/upload/uploaddialog.cpp
+++ b/src/upload/uploaddialog.cpp
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  <copyright holder> <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/uploaddialog.h
+++ b/src/upload/uploaddialog.h
@@ -1,0 +1,73 @@
+/*
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 2013  <copyright holder> <email>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#ifndef LXIMAGE_UPLOADDIALOG_H
+#define LXIMAGE_UPLOADDIALOG_H
+
+#include <QDialog>
+#include <QFile>
+
+#include "ui_uploaddialog.h"
+
+namespace LxImage {
+
+class Upload;
+
+/**
+ * @brief Dialog for uploading an image
+ */
+class UploadDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * @brief Create a dialog for uploading the specified file
+     * @param parent widget parent
+     * @param filename absolute path to file
+     */
+    UploadDialog(QWidget *parent, const QString &filename);
+
+private Q_SLOTS:
+
+    void on_actionButton_clicked();
+
+private:
+
+    void start();
+    void updateUi();
+    void showError(const QString &message);
+
+    Ui::UploadDialog ui;
+
+    enum {
+        SelectProvider,
+        UploadInProgress,
+        Completed,
+    } mState;
+
+    QFile mFile;
+
+    Upload *mUpload;
+};
+
+}
+
+#endif // LXIMAGE_UPLOADDIALOG_H

--- a/src/upload/uploaddialog.h
+++ b/src/upload/uploaddialog.h
@@ -1,6 +1,6 @@
 /*
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 2013  <copyright holder> <email>
+    LxImage - image viewer and screenshot tool for lxqt
+    Copyright (C) 2017  Nathan Osman <nathan@quickmediasolutions.com>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/upload/uploaddialog.ui
+++ b/src/upload/uploaddialog.ui
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UploadDialog</class>
+ <widget class="QDialog" name="UploadDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Upload</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QComboBox" name="providerComboBox"/>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLineEdit" name="linkLineEdit"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="actionButton">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/upload/uploaddialog.ui
+++ b/src/upload/uploaddialog.ui
@@ -27,7 +27,11 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLineEdit" name="linkLineEdit"/>
+      <widget class="QLineEdit" name="linkLineEdit">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
I decided to take a stab at bug #98.

The user interface I came up with is fairly simple.

1. The user clicks the "Edit->Upload" menu item and selects a provider:

    ![screenshot_20171020_000645](https://user-images.githubusercontent.com/1253444/31809041-c173e4d6-b52a-11e7-9572-a296ca181c1a.png)

2. The image is uploaded asynchronously:

    ![screenshot_20171020_000701](https://user-images.githubusercontent.com/1253444/31809044-c3bceea4-b52a-11e7-818f-e2575e2ec4ee.png)

3. Upon successful completion, the URL of the image is shown:

    ![screenshot_20171020_000720](https://user-images.githubusercontent.com/1253444/31809047-c6194d8c-b52a-11e7-944d-298f75252330.png)

Under the hood, I introduced a few new classes:

- UploadDialog takes care of presenting the UI to the user and displaying the status of the upload
- Provider is a base class for creating Upload objects, given a file opened for reading
- Upload is returned by Provider and emits signals to indicate upload status

This pull request includes support for Imgur uploads but the code is designed to easily allow more services to be supported.