### PR TITLE
Fix warnings issued by GCC and Clang.

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -41,7 +41,10 @@ Application::Application(int& argc, char** argv):
 }
 
 bool Application::init(int argc, char** argv) {
-    setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+  Q_UNUSED(argc)
+  Q_UNUSED(argv)
+
+  setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
   // install the translations built-into Qt itself
   qtTranslator.load("qt_" + QLocale::system().name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -628,7 +628,7 @@ void MainWindow::loadImage(const Fm::FilePath & filePath, QModelIndex index) {
     loadJob_ = new LoadImageJob(currentFile_);
     connect(loadJob_, &Fm::Job::finished, this, &MainWindow::onImageLoaded);
     connect(loadJob_, &Fm::Job::error, this
-        , [this] (const Fm::GErrorPtr & err, Fm::Job::ErrorSeverity /*severity*/, Fm::Job::ErrorAction & /*response*/)
+        , [] (const Fm::GErrorPtr & err, Fm::Job::ErrorSeverity /*severity*/, Fm::Job::ErrorAction & /*response*/)
           {
             // TODO: show a info bar?
             qWarning().noquote() << "lximage-qt:" << err.message();
@@ -647,7 +647,7 @@ void MainWindow::saveImage(const Fm::FilePath & filePath) {
   saveJob_ = new SaveImageJob(image_, filePath);
   connect(saveJob_, &Fm::Job::finished, this, &MainWindow::onImageSaved);
   connect(saveJob_, &Fm::Job::error, this
-        , [this] (const Fm::GErrorPtr & err, Fm::Job::ErrorSeverity /*severity*/, Fm::Job::ErrorAction & /*response*/)
+        , [] (const Fm::GErrorPtr & err, Fm::Job::ErrorSeverity /*severity*/, Fm::Job::ErrorAction & /*response*/)
         {
           // TODO: show a info bar?
           qWarning().noquote() << "lximage-qt:" << err.message();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -158,6 +158,6 @@ private:
   SaveImageJob* saveJob_;
 };
 
-};
+}
 
 #endif // LXIMAGE_MAINWINDOW_H

--- a/src/modelfilter.cpp
+++ b/src/modelfilter.cpp
@@ -32,6 +32,8 @@ ModelFilter::~ModelFilter() {
 
 bool ModelFilter::filterAcceptsRow(const Fm::ProxyFolderModel* model, const std::shared_ptr<const Fm::FileInfo>& info) const
 {
+  Q_UNUSED(model)
+
   // filter out non-image files and formats that we don't support.
   return info && info->isImage();
 }


### PR DESCRIPTION
As mentioned in issue #112, there are a handful of lines that cause compiler warnings when building lximage-qt. This pull request fixes the warnings by:

- removing unnecessary semicolons at the end of namespace declarations
- squelching warnings about unused parameters with `Q_UNUSED()`
- removing unused parameters captured by lambdas

I have tested this against both GCC 7.2 and Clang 5