### PR TITLE
Remove unnecessary QOverloads

### DIFF
--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -93,7 +93,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent):
 
   oldColorSpace_ = qBound(0, settings.colorSpace(), 5);
   ui.colorSpaceComboBox->setCurrentIndex(oldColorSpace_);
-  connect(ui.colorSpaceComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [](int index) {
+  connect(ui.colorSpaceComboBox, &QComboBox::currentIndexChanged, this, [](int index) {
     Settings& settings = static_cast<Application*>(qApp)->settings();
     settings.setColorSpace(index);
   });

--- a/src/resizeimagedialog.cpp
+++ b/src/resizeimagedialog.cpp
@@ -36,10 +36,10 @@ ResizeImageDialog::ResizeImageDialog(QWidget* parent):
   updateFromRatio_ = false;
   updateFromSizeOrPercentage_ = false;
 
-  connect(ui.widthSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &ResizeImageDialog::onWidthChanged);
-  connect(ui.heightSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &ResizeImageDialog::onHeightChanged);
-  connect(ui.widthPercentSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &ResizeImageDialog::onWidthPercentChanged);
-  connect(ui.heightPercentSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &ResizeImageDialog::onHeightPercentChanged);
+  connect(ui.widthSpinBox, &QSpinBox::valueChanged, this, &ResizeImageDialog::onWidthChanged);
+  connect(ui.heightSpinBox, &QSpinBox::valueChanged, this, &ResizeImageDialog::onHeightChanged);
+  connect(ui.widthPercentSpinBox, &QDoubleSpinBox::valueChanged, this, &ResizeImageDialog::onWidthPercentChanged);
+  connect(ui.heightPercentSpinBox, &QDoubleSpinBox::valueChanged, this, &ResizeImageDialog::onHeightPercentChanged);
   connect(ui.keepAspectCheckBox, &QCheckBox::toggled, this, &ResizeImageDialog::onKeepAspectChanged);
 }
 


### PR DESCRIPTION
There exist maybe ~~&nbsp;5&nbsp;~~ 1-3 more instances throughout all other components. This was the last component worth doing.